### PR TITLE
Feature/add gui process modal detection

### DIFF
--- a/driver/wmp_driver.cpp
+++ b/driver/wmp_driver.cpp
@@ -4,6 +4,7 @@
 #include <utils.h>
 #include <instrumentation.h>
 #include "driver.h"
+#include <wingui.h>
 
 //c headers
 #include <stdio.h>
@@ -176,6 +177,10 @@ int wmp_test_input(void * driver_state, char * input, size_t length)
 			return FUZZ_NONE;
 		
 		if (time(NULL) - start_time > state->timeout)
+			return FUZZ_HANG;
+		
+		// If we're stuck in a modal dialog we're "hung"
+		if (IsProcessInModalDialog(GetProcessId(state->child_handle)))
 			return FUZZ_HANG;
 		
 		Sleep(50);

--- a/driver/wmp_driver.cpp
+++ b/driver/wmp_driver.cpp
@@ -179,8 +179,8 @@ int wmp_test_input(void * driver_state, char * input, size_t length)
 		if (time(NULL) - start_time > state->timeout)
 			return FUZZ_HANG;
 		
-		// If we're stuck in a modal dialog we're "hung"
-		if (IsProcessInModalDialog(GetProcessId(&state->process)))
+		// If we're stuck in a modal dialog we're "hung". Works for debug, but not dynamorio
+		if (IsProcessInModalDialog(GetProcessId(state->process)))
 			return FUZZ_HANG;
 		
 		Sleep(50);

--- a/driver/wmp_driver.cpp
+++ b/driver/wmp_driver.cpp
@@ -180,7 +180,7 @@ int wmp_test_input(void * driver_state, char * input, size_t length)
 			return FUZZ_HANG;
 		
 		// If we're stuck in a modal dialog we're "hung"
-		if (IsProcessInModalDialog(GetProcessId(state->child_handle)))
+		if (IsProcessInModalDialog(GetProcessId(&state->process)))
 			return FUZZ_HANG;
 		
 		Sleep(50);

--- a/instrumentation/CMakeLists.txt
+++ b/instrumentation/CMakeLists.txt
@@ -11,6 +11,7 @@ if (WIN32)
 		${INSTRUMENTATION_SRC}
 		${PROJECT_SOURCE_DIR}/debug_instrumentation.c
 		${PROJECT_SOURCE_DIR}/dynamorio_instrumentation.c
+		${PROJECT_SOURCE_DIR}/wingui.c
 	)
 else ()
 	set(INSTRUMENTATION_SRC

--- a/instrumentation/wingui.c
+++ b/instrumentation/wingui.c
@@ -1,0 +1,42 @@
+#include <windows.h>
+/*
+ * Given a ProcessId this function will attempt to determine if it is
+ * "stuck" on a modal dialog. These are usualy some sport of error
+ * and flow stoppage without a full crash, forcing us to wait for
+ * timeout otherwise. We don't read the message, only know that it is
+ * there incase the other process hangs. We don't want to get stuck.
+ */
+BOOL IsProcessInModalDialog(
+    DWORD dwTargetProcessId
+)
+{
+    HWND hwndFoundDialog = NULL;
+    HWND hwndDialogOwner = NULL;
+    DWORD dwThreadId;
+    DWORD dwProcessId;
+    do
+    {
+        hwndFoundDialog = FindWindowExA( // Find a "Dialog" class window
+            GetDesktopWindow(),
+            hwndFoundDialog,
+            MAKEINTATOM(32770), // "#32770 (Dialog)"
+            NULL
+        );
+        if ( hwndFoundDialog )
+        {
+            hwndDialogOwner = GetWindow( hwndFoundDialog, GW_OWNER ); // Fetch it's owner
+
+            if ( !IsWindowEnabled( hwndDialogOwner ) ) // If owner is disabled, possibly modal dialog
+            {
+                dwThreadId = GetWindowThreadProcessId(
+                    hwndDialogOwner,
+                    &dwProcessId
+                );
+                if ( dwProcessId == dwTargetProcessId ) return TRUE;
+            }
+        }
+    } 
+    while ( hwndFoundDialog != NULL );
+
+    return FALSE;
+}

--- a/instrumentation/wingui.h
+++ b/instrumentation/wingui.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <windows.h>
+
+BOOL IsProcessInModalDialog( DWORD dwTargetProcessId );

--- a/instrumentation/wingui.h
+++ b/instrumentation/wingui.h
@@ -2,4 +2,4 @@
 
 #include <windows.h>
 
-BOOL IsProcessInModalDialog( DWORD dwTargetProcessId );
+extern "C" BOOL IsProcessInModalDialog( DWORD dwTargetProcessId );


### PR DESCRIPTION
Detect and move on from non-crash fail state faster. Just wmp_driver for now. Tested with dummy file.

`C:\killerbeez\build\X86\Debug\killerbeez>fuzzer.exe wmp debug nop -n 3 -sf "C:\Users\Chris\Downloads\test.wmv" -d "{\"timeout\":20}" -i "{\"timeout\":5000,\"coverage_modules\":[\"wmp.DLL\"],\"target_path\":\"C:\\Program Files (x86)\\Windows Media Player\\wmplayer.exe\"}"
Sat Dec 22 15:10:26 2018 - INFO     - Logging Started
Sat Dec 22 15:10:47 2018 - ERROR    - Found hangs
Sat Dec 22 15:11:08 2018 - ERROR    - Found hangs
Sat Dec 22 15:11:29 2018 - ERROR    - Found hangs
Sat Dec 22 15:11:29 2018 - INFO     - Ran 3 iterations in 63 seconds

C:\killerbeez\build\X86\Debug\killerbeez>fuzzer.exe wmp debug nop -n 3 -sf "C:\Users\Chris\Downloads\test.wmv" -d "{\"timeout\":20}" -i "{\"timeout\":5000,\"coverage_modules\":[\"wmp.DLL\"],\"target_path\":\"C:\\Program Files (x86)\\Windows Media Player\\wmplayer.exe\"}"
Sat Dec 22 15:12:37 2018 - INFO     - Logging Started
Sat Dec 22 15:12:38 2018 - ERROR    - Found hangs
Sat Dec 22 15:12:40 2018 - ERROR    - Found hangs
Sat Dec 22 15:12:41 2018 - ERROR    - Found hangs
Sat Dec 22 15:12:41 2018 - INFO     - Ran 3 iterations in 4 seconds

C:\killerbeez\build\X86\Debug\killerbeez>`